### PR TITLE
Fix issue with blank pod name/ns

### DIFF
--- a/webhook/main.go
+++ b/webhook/main.go
@@ -59,6 +59,15 @@ func applyAppdInstrumentation(req *admission.AdmissionRequest) ([]patchOperation
 		return nil, fmt.Errorf("could not deserialize pod object: %v", err)
 	}
 
+	// Check if pod fields are empty but we can fill from other sources
+	if len(pod.Name) == 0 && len(pod.GenerateName) > 0 {
+		pod.Name = pod.GenerateName
+	}
+
+	if len(pod.Namespace) == 0 && len(req.Namespace) > 0 {
+		pod.Namespace = req.Namespace
+	}
+
 	// Check if we have configuration sucessfully
 	if config.ControllerConfig == nil || config.InstrumentationConfig == nil {
 		return nil, fmt.Errorf("instrumentor configuration not read from configmap")


### PR DESCRIPTION
Pod Name / Namespace was blank in some scenarios.

## Description

Minor fix to fill in empty pod name with pod generatename and pod namespace from request namespace if empty.
Both these fields were empty in my EKS 1.22 cluster (and so no instrumentation rules would match).

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
