### PR TITLE
Allow running the apache-httpd test container image with non-root

### DIFF
--- a/testWorkloads/apache-httpd/Dockerfile
+++ b/testWorkloads/apache-httpd/Dockerfile
@@ -15,5 +15,9 @@
 
 
 FROM httpd:2.4
+
 COPY ./conf/ /usr/local/apache2/conf
 COPY ./public/ /usr/local/apache2/htdocs/
+
+# Allow running the container with non-root user
+RUN chmod 777 -R /usr/local/apache2/


### PR DESCRIPTION
When the container is run using a user ID, the execution fails because the process cannot write in some folders:
```sh
docker run -ti -u 1000:3000 docker.io/chrlic/apache-test@sha256:fad58c6ce7a4f477b455bece2a1980741fa6f81cef1e1093a3b72f9b2ffa7b8e
AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
[Tue Aug 29 15:59:05.403203 2023] [core:error] [pid 1:tid 140273862335808] (13)Permission denied: AH00099: could not create /usr/local/apache2/logs/httpd.pid.C4cRDh
[Tue Aug 29 15:59:05.403560 2023] [core:error] [pid 1:tid 140273862335808] AH00100: httpd: could not log pid to file /usr/local/apache2/logs/httpd.pid
```

Also, this affects when running in Kubernetes and using a security context.